### PR TITLE
fix: clean cors url

### DIFF
--- a/components/VodModal/index.tsx
+++ b/components/VodModal/index.tsx
@@ -7,9 +7,7 @@ import axios from 'axios';
 
 import { useGlobal } from '@/stores/GlobalContext';
 import { Container, HCaptchaContainer, CustomOptions } from './styles';
-
-const proxy1 = process.env.NEXT_PUBLIC_CORS as string;
-const proxy2 = process.env.NEXT_PUBLIC_CORS_1 as string;
+import { removeCorsFromUrl } from '@/utils/removeCorsFromUrl';
 
 interface IVodModal {
   videoUrl: string;
@@ -46,10 +44,9 @@ const VodModal = ({ videoUrl, previewUrl }: IVodModal) => {
 
     const clippedPart = Math.floor(currentTime / 10);
 
-    const clippedUrl = videoUrl
-      .replace('index-dvr.m3u8', `${clippedPart}.ts`)
-      .replace(proxy1, '')
-      .replace(proxy2, '');
+    const clippedUrl = removeCorsFromUrl(
+      videoUrl.replace('index-dvr.m3u8', `${clippedPart}.ts`),
+    );
 
     const link = document.createElement('a');
     link.href = clippedUrl;
@@ -82,7 +79,7 @@ const VodModal = ({ videoUrl, previewUrl }: IVodModal) => {
             <Player
               playsInline
               poster={previewUrl || ''}
-              src={videoUrl.replace(proxy1, '').replace(proxy2, '')}
+              src={removeCorsFromUrl(videoUrl)}
             />
           </>
         ) : (

--- a/utils/removeCorsFromUrl.ts
+++ b/utils/removeCorsFromUrl.ts
@@ -1,0 +1,21 @@
+/**
+ * @name removeCorsFromUrl
+ * @param {string} url
+ * @returns {string}
+ * @description
+ * Removes the cors url from the url.
+ * @example
+ * removeCorsFromUrl('https://cors-anywhere.herokuapp.com/https://www.twitch.tv/videos/123456789');
+ * // returns 'https://www.twitch.tv/videos/123456789'
+ */
+
+export const removeCorsFromUrl = (url: string) => {
+  const corsRegex = /https:\/\/(.*)\/https:\/\//;
+  const cors = corsRegex.exec(url);
+
+  if (cors) {
+    return url.replace(corsRegex, 'https://');
+  }
+
+  return url;
+};


### PR DESCRIPTION
Since we updated how we handled cors servers from environment variables we broke some stuff, especially how we we're replacing the url string.

- Completely remove the cors url from iOS users
- Completely remove the cors url from download clips