### PR TITLE
refact: use gql instead of v5 twitch api

### DIFF
--- a/src/@types/Twitch/gql/IGQLTwitchVideo.ts
+++ b/src/@types/Twitch/gql/IGQLTwitchVideo.ts
@@ -1,0 +1,17 @@
+export interface IGQLTwitchVideo {
+  id: string
+  previewThumbnailURL: string
+  createdAt: string
+  lengthSeconds: number
+  title: string
+  viewCount: number
+  owner: {
+    displayName: string
+    login: string
+    description: string
+    profileImageURL: string
+    followers: {
+      totalCount: number
+    }
+  }
+}

--- a/src/@types/VodInformation.ts
+++ b/src/@types/VodInformation.ts
@@ -1,5 +1,3 @@
-import { VideoUrl } from './VideoUrl'
-
 export interface VodInformation {
   id: string
   thumbnail: string

--- a/src/adapters/videoAdapter.ts
+++ b/src/adapters/videoAdapter.ts
@@ -1,24 +1,24 @@
-import { ITwitchVideo } from '~/@types/ITwitchVideo'
 import { IVideo } from '~/@types/IVideo'
 import { StreamerInformation } from '~/@types/StreamerInformation'
+import { IGQLTwitchVideo } from '~/@types/Twitch/gql/IGQLTwitchVideo'
 import { VodInformation } from '~/@types/VodInformation'
 
-export const videoAdapter = (video: ITwitchVideo): IVideo => {
+export const videoAdapter = (video: IGQLTwitchVideo): IVideo => {
   const streamerInformation: StreamerInformation = {
-    name: video.channel.name,
-    logo: video.channel.logo,
-    displayName: video.channel.display_name,
-    followers: video.channel.followers,
-    description: video.channel.description,
+    name: video.owner.login,
+    logo: video.owner.profileImageURL,
+    displayName: video.owner.displayName,
+    followers: video.owner.followers.totalCount,
+    description: video.owner.description,
   }
 
   const vodInformation: VodInformation = {
     title: video.title,
-    date: video.created_at as string,
-    duration: video.length,
-    id: video._id.replace('v', ''),
-    thumbnail: video.preview.medium,
-    viewCount: video.views,
+    date: video.createdAt,
+    duration: video.lengthSeconds,
+    id: video.id,
+    thumbnail: video.previewThumbnailURL,
+    viewCount: video.viewCount,
   }
 
   return {

--- a/src/components/screens/DeletedVods/[streamer].tsx
+++ b/src/components/screens/DeletedVods/[streamer].tsx
@@ -10,7 +10,7 @@ interface DeletedVodsProps {
 }
 
 const DeletedVods = ({ videos, isUserRemoved }: DeletedVodsProps) => {
-  const { videosData, getNewVideos, hasMore } = useDeletedVods(videos)
+  const { videosData } = useDeletedVods(videos)
 
   const streamerInformation = {
     displayName: videos[0].displayName,

--- a/src/components/screens/DeletedVods/[streamer].tsx
+++ b/src/components/screens/DeletedVods/[streamer].tsx
@@ -1,5 +1,3 @@
-import { Skeleton } from '@mui/material'
-import InfiniteScroll from 'react-infinite-scroll-component'
 import { IDeletedVods } from '~/@types/IDeletedVods'
 import RemovedUser from '~/components/atoms/RemovedUser'
 import { DeletedVodsTable } from '~/components/organisms/DeletedVodsTable'
@@ -27,22 +25,7 @@ const DeletedVods = ({ videos, isUserRemoved }: DeletedVodsProps) => {
       {isUserRemoved && typeof window !== undefined ? (
         <RemovedUser />
       ) : (
-        <InfiniteScroll
-          dataLength={videosData.length}
-          next={getNewVideos}
-          hasMore={hasMore}
-          loader={
-            <Skeleton
-              variant="rectangular"
-              animation="wave"
-              width={'100%'}
-              height={150}
-            />
-          }
-          endMessage={null}
-        >
-          <DeletedVodsTable videos={videosData} />
-        </InfiniteScroll>
+        <DeletedVodsTable videos={videosData} />
       )}
     </ProfilePage>
   )

--- a/src/components/screens/DeletedVods/hooks.ts
+++ b/src/components/screens/DeletedVods/hooks.ts
@@ -27,5 +27,5 @@ export const useDeletedVods = (data: IDeletedVods[]) => {
     }
   }
 
-  return { videosData, getNewVideos, hasMore }
+  return { videosData, hasMore }
 }

--- a/src/components/screens/Home/hooks.ts
+++ b/src/components/screens/Home/hooks.ts
@@ -40,10 +40,14 @@ export const useHome = (data: IVideo[]) => {
       offset: videosData.length,
     })
 
-    const newVideos = topVideos.vods.map(videoAdapter)
+    const newVideos = topVideos?.map(videoAdapter)
+
+    if (!newVideos?.length) {
+      return
+    }
 
     setVideosData([...videosData, ...newVideos])
   }
 
-  return { videosData, getNewVideos, texts, watchedVideosData }
+  return { videosData, texts, watchedVideosData }
 }

--- a/src/components/screens/Home/index.tsx
+++ b/src/components/screens/Home/index.tsx
@@ -1,5 +1,3 @@
-import { Skeleton } from '@mui/material'
-import InfiniteScroll from 'react-infinite-scroll-component'
 import { IVideo } from '~/@types/IVideo'
 import AdsContainer from '~/components/atoms/AdsContainer'
 import Box from '~/components/atoms/Box'
@@ -47,22 +45,7 @@ const Home = ({ videos }: HomeProps) => {
           {texts.MOST_POPULAR_VODS_TODAY}
         </Typography>
       </Box>
-      <InfiniteScroll
-        dataLength={videosData.length}
-        next={getNewVideos}
-        hasMore={videosData.length <= 500}
-        loader={
-          <Skeleton
-            variant="rectangular"
-            animation="wave"
-            width={'100%'}
-            height={170}
-          />
-        }
-        endMessage={null}
-      >
-        <VideoButtonGroup videos={videosData} />
-      </InfiniteScroll>
+      <VideoButtonGroup videos={videosData} />
     </S.Container>
   )
 }

--- a/src/components/screens/Home/index.tsx
+++ b/src/components/screens/Home/index.tsx
@@ -12,7 +12,7 @@ interface HomeProps {
 }
 
 const Home = ({ videos }: HomeProps) => {
-  const { videosData, getNewVideos, texts, watchedVideosData } = useHome(videos)
+  const { videosData, texts, watchedVideosData } = useHome(videos)
 
   return (
     <S.Container>

--- a/src/components/screens/Videos/[streamer].tsx
+++ b/src/components/screens/Videos/[streamer].tsx
@@ -13,8 +13,7 @@ interface VideoProps {
 }
 
 const Videos = ({ videos, isUserRemoved }: VideoProps) => {
-  const { videosData, getNewVideos, streamerInformation, hasMore } =
-    useVideos(videos)
+  const { videosData, streamerInformation } = useVideos(videos)
 
   return (
     <ProfilePage

--- a/src/components/screens/Videos/[streamer].tsx
+++ b/src/components/screens/Videos/[streamer].tsx
@@ -25,22 +25,7 @@ const Videos = ({ videos, isUserRemoved }: VideoProps) => {
         {isUserRemoved ? (
           <RemovedUser />
         ) : (
-          <InfiniteScroll
-            dataLength={videosData.length}
-            next={getNewVideos}
-            hasMore={hasMore}
-            loader={
-              <Skeleton
-                variant="rectangular"
-                animation="wave"
-                width={'100%'}
-                height={200}
-              />
-            }
-            endMessage={null}
-          >
-            <VideoButtonGroup videos={videosData} />
-          </InfiniteScroll>
+          <VideoButtonGroup videos={videosData} />
         )}
       </Box>
     </ProfilePage>

--- a/src/components/screens/Videos/hooks.ts
+++ b/src/components/screens/Videos/hooks.ts
@@ -15,10 +15,9 @@ export const useVideos = (data: IVideo[]) => {
     const streamerVideos = await getStreamerVideos({
       streamerName: data[0].streamerInformation.name,
       limit: 8,
-      offset: videosData.length,
     })
 
-    const newVideos = streamerVideos?.videos.map(videoAdapter)
+    const newVideos = streamerVideos?.map(videoAdapter)
 
     if (newVideos?.length) {
       setVideosData([...videosData, ...newVideos])
@@ -29,5 +28,5 @@ export const useVideos = (data: IVideo[]) => {
 
   const streamerInformation = data.length ? data[0].streamerInformation : null
 
-  return { videosData, getNewVideos, hasMore, streamerInformation }
+  return { videosData, streamerInformation }
 }

--- a/src/lib/gql/twitchVideoQuery.ts
+++ b/src/lib/gql/twitchVideoQuery.ts
@@ -1,0 +1,17 @@
+export const twitchVideoQuery = `
+  id
+  previewThumbnailURL(height: 180, width: 320)
+  createdAt
+  lengthSeconds
+  title
+  viewCount
+  owner {
+    displayName
+    login
+    description
+    profileImageURL(width: 150)
+    followers {
+      totalCount
+    }
+  }
+`

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,10 +7,10 @@ import { getTopVideos } from '~/services/api/getTopVideos'
 export const getStaticProps = async (context: GetStaticPropsContext) => {
   const topVideos = await getTopVideos({
     language: context.locale,
-    limit: 30,
+    limit: 64,
   })
 
-  const videos = topVideos.vods.map(videoAdapter)
+  const videos = topVideos?.map(videoAdapter) ?? []
 
   return {
     props: {

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -67,8 +67,12 @@ class Sitemap extends React.Component {
     let vods: string[] = []
 
     topVideos.forEach((videos) => {
-      streamers = streamers.concat(videos.vods.map((vod) => vod.channel.name))
-      vods = vods.concat(videos.vods.map((vod) => vod.broadcast_id.toString()))
+      if (!videos) {
+        return
+      }
+
+      streamers = streamers.concat(videos.map((vod) => vod.owner.login))
+      vods = vods.concat(videos.map((vod) => vod.id))
     })
 
     const dedupedStreamers = streamers.filter(

--- a/src/pages/videos/[streamer].tsx
+++ b/src/pages/videos/[streamer].tsx
@@ -38,7 +38,7 @@ export const getStaticProps = async (context: GetStaticPropsContext) => {
     }
   }
 
-  const videos = streamerVideos?.videos.map(videoAdapter)
+  const videos = streamerVideos?.map(videoAdapter)
 
   return {
     props: {

--- a/src/services/api/getStreamerVideos/index.ts
+++ b/src/services/api/getStreamerVideos/index.ts
@@ -1,52 +1,40 @@
-import { ITwitchChannelVideo } from '~/@types/ITwitchChannelVideo'
-import { ITwitchUser } from '~/@types/ITwitchUser'
-import api from '~/services/config'
+import { apiGQL } from '~/services/config'
+import { IGQLTwitchVideo } from '~/@types/Twitch/gql/IGQLTwitchVideo'
+import { twitchVideoQuery } from '~/lib/gql/twitchVideoQuery'
 
 interface IGetStreamerVideos {
   id?: string
   streamerName?: string
   limit?: number
-  offset?: number
-  sort?: string
-  language?: string[]
-  broadcast_type?: string[]
 }
 
 export const getStreamerVideos = async ({
-  id,
   streamerName,
   limit = 16,
-  offset = 0,
-  sort,
-  language,
-  broadcast_type,
-}: IGetStreamerVideos) => {
-  let _id = id
-
+}: IGetStreamerVideos): Promise<IGQLTwitchVideo[] | null> => {
   try {
-    if (!id) {
-      const { data } = await api.get<ITwitchUser>('/users', {
-        params: { login: streamerName },
-      })
+    const response = await apiGQL.post('', {
+      query: `
+        query {
+          user(login: "${streamerName?.toString()}") {
+            videos(first: ${limit}) {
+              edges {
+                node {
+                  ${twitchVideoQuery}
+                }
+              }
+            }
+          }
+        }
+      `,
+    })
 
-      _id = data.users[0]._id
-    }
-
-    const response = await api.get<ITwitchChannelVideo>(
-      `/channels/${_id}/videos`,
-      {
-        params: {
-          limit,
-          offset,
-          sort,
-          language,
-          broadcast_type,
-        },
-      },
+    return (
+      response?.data?.data?.user?.videos?.edges?.map(
+        ({ node }: { node: IGQLTwitchVideo }) => node,
+      ) ?? null
     )
-
-    return response.data
   } catch (err) {
-    return
+    return null
   }
 }

--- a/src/services/api/getTopVideos/index.ts
+++ b/src/services/api/getTopVideos/index.ts
@@ -1,26 +1,33 @@
-import api from '~/services/config'
-import { IGetTopVideos, ITwitchTopVideos } from './types'
+import { IGQLTwitchVideo } from '~/@types/Twitch/gql/IGQLTwitchVideo'
+import { twitchVideoQuery } from '~/lib/gql/twitchVideoQuery'
+import { apiGQL } from '~/services/config'
+import { IGetTopVideos } from './types'
 
 export const getTopVideos = async ({
   limit = 10,
-  offset = 0,
-  game = '',
-  period = 'week',
-  language = '',
-  sort = 'views',
-}: IGetTopVideos) => {
-  const query = {
-    limit,
-    offset,
-    game,
-    period,
-    language,
-    sort,
+  language = 'EN',
+}: IGetTopVideos): Promise<IGQLTwitchVideo[] | null> => {
+  try {
+    const response = await apiGQL.post('', {
+      query: `
+      query {
+        videos(first: ${limit}, language: ${language.toUpperCase()}) {
+          edges {
+            node {
+              ${twitchVideoQuery}
+            }
+          }
+        }
+      }
+    `,
+    })
+
+    return (
+      response?.data?.data?.videos?.edges?.map(
+        ({ node }: { node: IGQLTwitchVideo }) => node,
+      ) ?? null
+    )
+  } catch (err) {
+    return null
   }
-
-  const response = await api.get<ITwitchTopVideos>('/videos/top', {
-    params: query,
-  })
-
-  return response.data
 }

--- a/src/services/api/getVideo/index.ts
+++ b/src/services/api/getVideo/index.ts
@@ -1,8 +1,21 @@
-import { ITwitchVideo } from '~/@types/ITwitchVideo'
-import api from '~/services/config'
+import { IGQLTwitchVideo } from '~/@types/Twitch/gql/IGQLTwitchVideo'
+import { twitchVideoQuery } from '~/lib/gql/twitchVideoQuery'
+import { apiGQL } from '~/services/config'
 
 export const getVideo = async (id: number | string) => {
-  const response = await api.get<ITwitchVideo>(`/videos/${id}`)
+  try {
+    const response = await apiGQL.post('', {
+      query: `
+      query {
+        video(id: ${id.toString()}) {
+          ${twitchVideoQuery}
+        }
+      }
+    `,
+    })
 
-  return response.data
+    return response.data.data.video as IGQLTwitchVideo
+  } catch (err) {
+    return null
+  }
 }

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -17,6 +17,14 @@ const apiV6 = axios.create({
   },
 })
 
+const apiGQL = axios.create({
+  baseURL: 'https://gql.twitch.tv/gql',
+  headers: {
+    'Client-Id': process.env.NEXT_PUBLIC_TWITCH_GQL_TOKEN as string,
+    'Content-Type': 'application/json',
+  },
+})
+
 const scraper = axios.create({
   headers: {
     'User-Agent': new UserAgent().toString(),
@@ -24,4 +32,4 @@ const scraper = axios.create({
 })
 
 export default api
-export { apiV6, scraper }
+export { apiV6, scraper, apiGQL }

--- a/src/utils/getQualitiesFromUrl/index.ts
+++ b/src/utils/getQualitiesFromUrl/index.ts
@@ -15,7 +15,7 @@ export const getQualitiesFromUrl = async (url: string): Promise<VideoUrl[]> => {
   let urlObjects = availableUrls.map((response, index) => {
     if (response.status === 'fulfilled') {
       return {
-        resolution: resolutions[index + 1],
+        resolution: resolutions[index],
         url: url.replace('chunked', qualities[index]),
       }
     }

--- a/src/utils/getUrlFromVideo/getUrlsFromVideo.ts
+++ b/src/utils/getUrlFromVideo/getUrlsFromVideo.ts
@@ -1,87 +1,15 @@
-// Source: Adapted from https://greasyfork.org/en/scripts/420212-twitch-vod-unblocker/code
+export const getUrlsFromVideo = (
+  animatedPreviewUrl: string,
+  isHighlight?: boolean,
+  id?: string,
+) => {
+  const fullUrl = new URL(animatedPreviewUrl)
+  const hostUrl = fullUrl.hostname
+  const cleanedPath = fullUrl.pathname.replace(/\/storyboards.*/, '')
 
-import { Resolutions } from '~/@types/ITwitchCommons'
-import { ITwitchVideo } from '~/@types/ITwitchVideo'
-import { VideoUrl } from '~/@types/VideoUrl'
-
-const THUMBNAIL_TO_ID_REGEX = /^https?:\/\/(?:[\w\.\/]+)\/(.+)\/storyboards/
-
-const getVideoResolutions = (video: ITwitchVideo): Resolutions => {
-  const keys = Object.keys(video.resolutions) as Array<keyof Resolutions>
-
-  if (keys.length === 1) {
-    return video.resolutions
+  if (isHighlight) {
+    return `https://${hostUrl}${cleanedPath}/chunked/highlight-${id}.m3u8`
   }
 
-  keys.pop()
-
-  const resolutions: Resolutions = {}
-
-  keys.forEach((key, index: number) => {
-    // @ts-ignore
-    resolutions[key] = video.resolutions[keys[index]]
-  })
-
-  if (resolutions['720p30'] && resolutions['720p60']) {
-    delete resolutions['720p60']
-  }
-
-  return resolutions
-}
-
-const getVideoHostUrl = (video: ITwitchVideo) => {
-  const fullUrl = new URL(video.animated_preview_url)
-  return fullUrl.hostname
-}
-
-const getChannelName = (video: ITwitchVideo) => video.channel.name
-const getVideoPartId = (video: ITwitchVideo) => {
-  const thumbnailUrl = video.animated_preview_url
-  const matched = thumbnailUrl.match(THUMBNAIL_TO_ID_REGEX) as RegExpMatchArray
-  return matched[1]
-}
-
-const getUploadedVideoUrls = (video: ITwitchVideo) => {
-  const videoId = video._id.replace('v', '')
-  const resolutions = getVideoResolutions(video)
-  const hostUrl = getVideoHostUrl(video)
-  const partId = getVideoPartId(video)
-  const channelName = getChannelName(video)
-  return Object.entries(resolutions).map(([resolutionForUrl, resolution]) => ({
-    resolution,
-    url: `https://${hostUrl}/${channelName}/${videoId}/${partId}/${resolutionForUrl}/index-dvr.m3u8`,
-  })) as VideoUrl[]
-}
-
-const getBroadcastArchiveUrls = (video: ITwitchVideo) => {
-  const resolutions = getVideoResolutions(video)
-  const hostUrl = getVideoHostUrl(video)
-  const partId = getVideoPartId(video)
-  return Object.entries(resolutions).map(([resolutionForUrl, resolution]) => ({
-    resolution,
-    url: `https://${hostUrl}/${partId}/${resolutionForUrl}/index-dvr.m3u8`,
-  })) as VideoUrl[]
-}
-
-const getHighlightUrls = (video: ITwitchVideo) => {
-  const videoId = video._id.replace('v', '')
-  const resolutions = getVideoResolutions(video)
-  const hostUrl = getVideoHostUrl(video)
-  const partId = getVideoPartId(video)
-  return Object.entries(resolutions).map(([resolutionForUrl, resolution]) => ({
-    resolution,
-    url: `https://${hostUrl}/${partId}/${resolutionForUrl}/highlight-${videoId}.m3u8`,
-  })) as VideoUrl[]
-}
-
-export const getUrlsFromVideo = (video: ITwitchVideo) => {
-  switch (video.broadcast_type) {
-    case 'highlight':
-      return getHighlightUrls(video)
-    case 'upload':
-      return getUploadedVideoUrls(video)
-    case 'archive':
-    default:
-      return getBroadcastArchiveUrls(video)
-  }
+  return `https://${hostUrl}${cleanedPath}/chunked/index-dvr.m3u8`
 }


### PR DESCRIPTION
So, the glorious v5 of twitch api is being deprecated next month :(
I had two options here, upgrate to v6 or use the undocumented graphql api
  - Since v6 has some differences in how it structured the `videos` endpoint compared to v5, we'd have to make between 2 and 3 requests to get the same data.
  - I had no experience in graphql prior to this pull request, but I really liked how it turned out, making only one request getting everything I needed to build the page is awesome. The adapter pattern really helped making things simple, I'll definitelly keep using the adapted pattern, if this gql endpoint change, it wouldn't be too hard to go to v6 (1~2 days max)