### PR TITLE
feat: show toast on video error

### DIFF
--- a/src/components/screens/Video/[vod].tsx
+++ b/src/components/screens/Video/[vod].tsx
@@ -62,6 +62,7 @@ const Video = ({ video, relatedVideos }: VideoProps) => {
                 video.streamerInformation.name ||
                 ''
               }
+              notFoundText={texts.VIDEO_NOT_FOUND}
             />
           </PlayerContainer>
           <Box

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -28,6 +28,7 @@ const en = {
     'We\'re still in our beta phase, so if you find any bugs, please report them in the "Feedback" button in the top right corner or in the menu if you\'re on mobile. Thank you!',
   REMOVED_USER_MESSAGE: 'Removed',
   YOUR_LAST_WATCHED_VODS: 'Your last watched VODs',
+  VIDEO_NOT_FOUND: 'This video has been deleted',
 }
 
 export default en

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -29,6 +29,7 @@ const es: Locale = {
   POGU_LIVE_BETA_DESCRIPTION: `Aún estamos en fase de beta, así que es posible que algunos recursos no funcionen como esperado. Si encuentras algún problema, por favor, reporta-lo en el botón Comentarios en la parte superior derecha o en el menú.`,
   REMOVED_USER_MESSAGE: 'Eliminado',
   YOUR_LAST_WATCHED_VODS: 'Tus últimos VODs vistos',
+  VIDEO_NOT_FOUND: 'Este vídeo ha sido eliminado',
 }
 
 export default es

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -30,6 +30,7 @@ const fr: Locale = {
     'Nous sommes encore en phase de bêta, si vous trouvez un bug, merci de le signaler avec le bouton "Feedback" en haut à droite ou dans le menu si vous êtes sur mobile. Merci !',
   REMOVED_USER_MESSAGE: 'Supprimé',
   YOUR_LAST_WATCHED_VODS: 'Vos derniers VODs vus',
+  VIDEO_NOT_FOUND: 'Cette vidéo a été supprimée',
 }
 
 export default fr

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -30,6 +30,7 @@ const pt: Locale = {
   POGU_LIVE_BETA_DESCRIPTION: `Ainda estamos na fase de beta, então é possível que alguns recursos não funcionem como esperado. Se você encontrar algum problema, por favor, reporte-o no botão Feedback no canto superior direito ou no menu.`,
   REMOVED_USER_MESSAGE: 'Removido',
   YOUR_LAST_WATCHED_VODS: 'Seus últimos VODs assistidos',
+  VIDEO_NOT_FOUND: 'Este vídeo foi deletado',
 }
 
 export default pt


### PR DESCRIPTION
- Sometimes we return a correct .m3u8 url but the chunks return a 403 error, when this happened the player showed an indefinitely load. Now we just return a toast saying that the video is deleted/unavailable